### PR TITLE
fix: Change tool to only analyse files passed as input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN chmod a+x /usr/lib/libsourcekitdInProc.so /usr/lib/libBlocksRuntime.so
 
 RUN apt-get -q update && \
     apt-get -q install -y --no-install-recommends openjdk-8-jre libatomic1 libcurl3 libbsd0 libxml2 wget && \
-    wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu55_55.1-7ubuntu0.4_amd64.deb && \
-    dpkg -i libicu55_55.1-7ubuntu0.4_amd64.deb && \
+    wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu55_55.1-7ubuntu0.5_amd64.deb && \
+    dpkg -i libicu55_55.1-7ubuntu0.5_amd64.deb && \
     apt-get remove --purge -y wget && \
     apt-get clean && \
-    rm -rf libicu55_55.1-7ubuntu0.4_amd64.deb /var/lib/apt/lists/*
+    rm -rf libicu55_55.1-7ubuntu0.5_amd64.deb /var/lib/apt/lists/*
 
 CMD swiftlint version

--- a/build.sbt
+++ b/build.sbt
@@ -15,15 +15,7 @@ enablePlugins(AshScriptPlugin)
 
 enablePlugins(DockerPlugin)
 
-scalacOptions ++= Seq(
-  "-Ywarn-unused:implicits",
-  "-Ywarn-unused:imports",
-  "-Ywarn-unused:locals",
-  "-Ywarn-unused:params",
-  "-Ywarn-unused:patvars",
-  "-Ywarn-unused:privates",
-  "-Xfatal-warnings"
-)
+scalacOptions ++= Seq("-Ywarn-unused:_", "-Xfatal-warnings")
 
 lazy val toolVersionKey = settingKey[String]("The version of the underlying tool retrieved from patterns.json")
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,16 @@ enablePlugins(AshScriptPlugin)
 
 enablePlugins(DockerPlugin)
 
+scalacOptions ++= Seq(
+  "-Ywarn-unused:implicits",
+  "-Ywarn-unused:imports",
+  "-Ywarn-unused:locals",
+  "-Ywarn-unused:params",
+  "-Ywarn-unused:patvars",
+  "-Ywarn-unused:privates",
+  "-Xfatal-warnings"
+)
+
 lazy val toolVersionKey = settingKey[String]("The version of the underlying tool retrieved from patterns.json")
 
 toolVersionKey := {

--- a/src/main/scala/codacy/swiftlint/SwiftLint.scala
+++ b/src/main/scala/codacy/swiftlint/SwiftLint.scala
@@ -76,14 +76,15 @@ object SwiftLint extends Tool {
     config.orElse(nativeConfig)
   }
 
-  private def commandToRun(configOpt: Option[String], files: List[String]): List[String] = {
+  private def commandToRun(configOpt: Option[String], file: String): List[String] = {
     val baseCmd = List("swiftlint", "lint", "--quiet", "--reporter", "json")
 
-    configOpt match {
+    val configCmd = configOpt match {
       case Some(opt) =>
         baseCmd ++ List("--config", opt)
       case None => baseCmd
     }
+    configCmd ++ List(file)
   }
 
   private def runToolCommand(
@@ -126,7 +127,7 @@ object SwiftLint extends Tool {
       val cfgOpt = lintConfiguration(source, configuration)
 
       filesToLint.flatMap { file =>
-        val command: List[String] = commandToRun(cfgOpt, List(file))
+        val command: List[String] = commandToRun(cfgOpt, file)
 
         val fileCommandAnalysisResult = runToolCommand(command, source, cfgOpt)
         fileCommandAnalysisResult match {

--- a/src/main/scala/codacy/swiftlint/SwiftLint.scala
+++ b/src/main/scala/codacy/swiftlint/SwiftLint.scala
@@ -84,7 +84,7 @@ object SwiftLint extends Tool {
         baseCmd ++ List("--config", opt)
       case None => baseCmd
     }
-    configCmd ++ List(file)
+    configCmd :+ file
   }
 
   private def runToolCommand(


### PR DESCRIPTION
The bug caused the tool to run for every file times the number of files. Now it should only run once per file.

Fix codacy/codacy-meta#390