### PR TITLE
bump: Bump swiftlint to 0.40.0 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:0.39.2 as builder
+FROM norionomura/swiftlint:0.40.0 as builder
 
 FROM swift:5.2.4-xenial-slim
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:0.39.2 as builder
+FROM norionomura/swiftlint:0.40.0 as builder
 
 FROM swift:5.2.4-xenial-slim
 


### PR DESCRIPTION
This should fix the problem related to incorrect JSON being outputted by tool
Fix #19
Fix CY-2525