### PR TITLE
Use batching instead of individual runs per file

### DIFF
--- a/docs/tests/scriptFile.scala
+++ b/docs/tests/scriptFile.scala
@@ -1,1 +1,0 @@
-closure_end_indentation

--- a/src/main/scala/codacy/swiftlint/SwiftLint.scala
+++ b/src/main/scala/codacy/swiftlint/SwiftLint.scala
@@ -3,12 +3,11 @@ package codacy.swiftlint
 import java.nio.file.{Path, Paths}
 
 import com.codacy.plugins.api.results.{Pattern, Result, Tool}
-import com.codacy.plugins.api.{ErrorMessage, Options, Source}
+import com.codacy.plugins.api.{Options, Source}
 import com.codacy.tools.scala.seed.utils.{CommandRunner, FileHelper}
 import com.codacy.tools.scala.seed.utils.ToolHelper._
 import play.api.libs.json._
 import better.files._
-import com.codacy.plugins.api.results.Result.FileError
 
 import scala.util.{Failure, Properties, Success, Try}
 
@@ -103,24 +102,14 @@ object SwiftLint extends Tool {
       options: Map[Options.Key, Options.Value]
   )(implicit specification: Tool.Specification): Try[List[Result]] = {
     Try {
-
       val filesToLint = listOfFilesToLint(files, source)
 
       val cfgOpt = configsFromCodacyConfiguration(configuration)
 
       val command: List[String] = commandToRun(cfgOpt, filesToLint)
 
-      runToolCommand(command, source, cfgOpt) match {
-        case Success(res) => res
-        case Failure(exception) =>
-          List(
-            FileError(
-              Source.File(source.path),
-              Some(ErrorMessage(s"Failed to analyse source ${source.path}: ${exception.getMessage}"))
-            )
-          )
-      }
-    }
+      runToolCommand(command, source, cfgOpt)
+    }.flatten
   }
 
   private def writeConfigFile(patternsToLint: List[Pattern.Definition]): Path = {

--- a/src/main/scala/codacy/swiftlint/SwiftLint.scala
+++ b/src/main/scala/codacy/swiftlint/SwiftLint.scala
@@ -57,7 +57,7 @@ object SwiftLint extends Tool {
     }
   }
 
-  private def commandToRun(configOpt: Option[String], file: String): List[String] = {
+  private def commandToRun(configOpt: Option[String], files: List[String]): List[String] = {
     val baseCmd = List("swiftlint", "lint", "--quiet", "--reporter", "json")
 
     val configCmd = configOpt match {
@@ -65,7 +65,8 @@ object SwiftLint extends Tool {
         baseCmd ++ List("--config", opt)
       case None => baseCmd
     }
-    configCmd :+ file
+
+    configCmd ++ files
   }
 
   private def runToolCommand(
@@ -107,17 +108,17 @@ object SwiftLint extends Tool {
 
       val cfgOpt = configsFromCodacyConfiguration(configuration)
 
-      filesToLint.flatMap { file =>
-        val command: List[String] = commandToRun(cfgOpt, file)
+      val command: List[String] = commandToRun(cfgOpt, filesToLint)
 
-        val fileCommandAnalysisResult = runToolCommand(command, source, cfgOpt)
-        fileCommandAnalysisResult match {
-          case Success(res) => res
-          case Failure(exception) =>
-            List(
-              FileError(Source.File(file), Some(ErrorMessage(s"Failed to analyse file $file: ${exception.getMessage}")))
+      runToolCommand(command, source, cfgOpt) match {
+        case Success(res) => res
+        case Failure(exception) =>
+          List(
+            FileError(
+              Source.File(source.path),
+              Some(ErrorMessage(s"Failed to analyse source ${source.path}: ${exception.getMessage}"))
             )
-        }
+          )
       }
     }
   }


### PR DESCRIPTION
Somewhere along Codacy's lifetime swiftlint was changed to run individually for each file which was resulting in constant an pervasive timeouts at 15 minutes (from testing, the tool would take close to 2 hours to be able to analyse a frequent workload -- under version `0.61.0`). This was happening because starting up all the swiftlint machinery was quite expensive and time consuming (~1 minute) and was being done for each individual file.

Seemingly, with a bump to version `0.63.2` this problem basically all but vanishes, as a workload that was takin 1:55:33 to be performed under `0.61.0` would take 00:01:29 under `0.63.2` therefore greatly mitigating the original issue.

Still, batching (giving the tool a list of all the files to be analysed) significant performance improvements, reducing the analysis time from 90 seconds to 10 seconds.

Assuming the same workload (100 files):

**0.61.0 sequential:**
* `01:55:33` (~2 hours) 
* `docker run --rm -t -e TIMEOUT_SECONDS="18000" --net=none --cap-drop=ALL     -  0.20s user 0.07s system 0% cpu 1:55:33.54 total`

**0.63.2 sequential:**
* `00:01:26` (~1:30 minutes)
* `docker run --rm -t --net=none --cap-drop=ALL --security-opt=no-new-privileges  0.08s user 0.04s system 0% cpu 1:26.32 total`

**0.63.2 batch:**
* `00:00:09` (~10 seconds)
* docker run --rm -t --net=none --cap-drop=ALL --security-opt=no-new-privileges  0.08s user 0.04s system 1% cpu 9.682 total

The generated results across versions and approaches seem to be similar, so the change is apparently a net positive. Unfortunately it was not really possible to fully confirm the motivations that originally had moved swiflint from batch to sequential.

[TAROT-3633](https://codacy.atlassian.net/browse/TAROT-3633)
<img width="1694" height="1369" alt="Screenshot 2026-02-09 at 10 22 40" src="https://github.com/user-attachments/assets/04717251-5661-4485-be74-1bb5beb7c15c" />

[Metabase dashboard](https://codacy.metabaseapp.com/dashboard/133-swiftlint-timeouts):
<img width="1075" height="1265" alt="Screenshot 2026-02-09 at 10 57 37" src="https://github.com/user-attachments/assets/fb5045df-2a82-44f5-b418-ca302870b177" />


[TAROT-3633]: https://codacy.atlassian.net/browse/TAROT-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ